### PR TITLE
Split ${CROSS_CFLAGS} into ${CFLAGS} and ${CROSS_CFLAGS} (#9)

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,29 +11,30 @@ WINDRES=i686-w64-mingw32-windres
 CC=gcc
 STRIP=strip
 
-CFLAGS=-Wall -O2 -static -I include -I expat/include -L /usr/local/lib -L /usr/lib -L lib -L expat/lib
+CFLAGS=-Wall -O2
+CROSS_CFLAGS=${CFLAGS} -static -I include -I expat/include -L /usr/local/lib -L /usr/lib -L lib -L expat/lib
 
 default:newflasher.exe newflasher.x64 newflasher.i386 newflasher.arm32 newflasher.arm64
 
 newflasher.exe:
 	${WINDRES} newflasher.rc -O coff -o newflasher.res
-	${CCWIN} ${CFLAGS} newflasher.c newflasher.res -o newflasher.exe -lsetupapi -lzwin -lexpat.win
+	${CCWIN} ${CROSS_CFLAGS} newflasher.c newflasher.res -o newflasher.exe -lsetupapi -lzwin -lexpat.win
 	${CCWINSTRIP} newflasher.exe
 
 newflasher.x64:
-	${CC} ${CFLAGS} newflasher.c -o newflasher.x64 -lz64 -lexpat.x64
+	${CC} ${CROSS_CFLAGS} newflasher.c -o newflasher.x64 -lz64 -lexpat.x64
 	${STRIP} newflasher.x64
 
 newflasher.i386:
-	${CC} ${CFLAGS} -m32 newflasher.c -o newflasher.i386 -lz32 -lexpat.i386
+	${CC} ${CROSS_CFLAGS} -m32 newflasher.c -o newflasher.i386 -lz32 -lexpat.i386
 	${STRIP} newflasher.i386
 
 newflasher.arm32:
-	${ARMCC} ${CFLAGS} newflasher.c -o newflasher.arm32 -lzarm32 -lexpat.arm32
+	${ARMCC} ${CROSS_CFLAGS} newflasher.c -o newflasher.arm32 -lzarm32 -lexpat.arm32
 	${ARMSTRIP} newflasher.arm32
 
 newflasher.arm64:
-	${ARMCC64} ${CFLAGS} newflasher.c -o newflasher.arm64 -lzarm64 -lexpat.arm64
+	${ARMCC64} ${CROSS_CFLAGS} newflasher.c -o newflasher.arm64 -lzarm64 -lexpat.arm64
 	${ARMSTRIP64} newflasher.arm64
 
 clean:


### PR DESCRIPTION
This separates the native compile options that use the system
installations of zlib and expat from the local cross-compiling options
that use the included vendored libraries.