### PR TITLE
Add Makefile target "newflasher" for dynamically linked native build (#9)

### DIFF
--- a/makefile
+++ b/makefile
@@ -16,6 +16,9 @@ CROSS_CFLAGS=${CFLAGS} -static -I include -I expat/include -L /usr/local/lib -L 
 
 default:newflasher.exe newflasher.x64 newflasher.i386 newflasher.arm32 newflasher.arm64
 
+newflasher: newflasher.c GordonGate.h
+	${CC} ${CFLAGS} $< -o $@ -lz -lexpat
+
 newflasher.exe:
 	${WINDRES} newflasher.rc -O coff -o newflasher.res
 	${CCWIN} ${CROSS_CFLAGS} newflasher.c newflasher.res -o newflasher.exe -lsetupapi -lzwin -lexpat.win


### PR DESCRIPTION
The previous targets for statically linked and cross-compiled binaries
are unchanged.

#9