### PR TITLE
templatized newflasher.spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /newflasher.exe
 /newflasher.i386
 /newflasher.rc
+/newflasher.spec
 /newflasher.res
 /newflasher.x64
 /newflasher.arm64_pie

--- a/makefile
+++ b/makefile
@@ -91,7 +91,7 @@ newflasher.arm64_pie:
 newflasher.1.gz: newflasher.1
 	gzip -9fkn $<
 
-spec:
+newflasher.spec:
 	sed "s/@VERSION@/$(VERSION)/" newflasher.spec.in > newflasher.spec
 
 .PHONY: install

--- a/makefile
+++ b/makefile
@@ -91,6 +91,9 @@ newflasher.arm64_pie:
 newflasher.1.gz: newflasher.1
 	gzip -9fkn $<
 
+spec:
+	sed "s/@VERSION@/$(VERSION)/" newflasher.spec.in > newflasher.spec
+
 .PHONY: install
 install: newflasher newflasher.1.gz
 	$(INSTALL) -o root -g root -d $(DESTDIR)/usr/bin

--- a/newflasher.spec.in
+++ b/newflasher.spec.in
@@ -13,7 +13,7 @@
 # published by the Open Source Initiative.
 
 
-%define pkg_version 55
+%define pkg_version @VERSION@
 Name:           newflasher
 Version:        %{pkg_version}
 Release:        1

--- a/newflasher.spec.in
+++ b/newflasher.spec.in
@@ -17,7 +17,7 @@
 Name:           newflasher
 Version:        %{pkg_version}
 Release:        1
-Summary:        Flash Sony Xperia firmwares for XZ Premium phones and later.
+Summary:        Flash Sony Xperia firmwares to XZ Premium devices and later.
 License:        MIT
 URL:            https://github.com/munjeni/newflasher
 Source0:        https://github.com/munjeni/newflasher/archive/refs/tags/%{pkg_version}.tar.gz
@@ -29,7 +29,7 @@ Requires:       zlib
 
 %description
 This _experimental_ software allows you to flash firmwares acquired
-through XperiFirm to Sony phones from the XZ Premium and newer.
+through XperiFirm to Sony devices beginning from the XZ Premium and newer.
 
 %prep
 %setup -q


### PR DESCRIPTION
avoid having to update pkg_version in newflasher.spec by making a makefile target for it that sets it from version.h, using the same method as used in the newflasher.exe target.

this should fulfill our discussion over at 7302a3eb04dab04ff3737e462a383ac8690fd34f